### PR TITLE
proposal to improve efficiency of mesh creation

### DIFF
--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -39,7 +39,6 @@ pub mod split;
 pub mod export;
 pub mod connected_components;
 pub mod validity;
-pub mod generation;
 
 mod connectivity_info;
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -137,7 +137,6 @@ impl Mesh
 				match twins.get(e) {
 					Some(&twin)	=> {
 						assert!(conn.halfedge(twin).unwrap().twin.is_none());
-						assert!(conn.halfedge(twin).unwrap().vertex != conn.halfedge(halfedge).unwrap().vertex);
 						conn.set_halfedge_twin(halfedge, twin);
 					},
 					None		=> { twins.insert(*e, halfedge); },
@@ -151,8 +150,6 @@ impl Mesh
 				conn.set_halfedge_twin(halfedge, conn.new_halfedge(Some(vertex), None, None));
 			}
         }
-        
-        mesh.is_valid().unwrap();
         
         mesh
     }

--- a/src/mesh/connectivity_info.rs
+++ b/src/mesh/connectivity_info.rs
@@ -147,6 +147,15 @@ impl ConnectivityInfo {
     {
         RefCell::borrow_mut(&self.faces).get_mut(id).unwrap().halfedge = Some(val);
     }
+    
+    pub fn remove_halfedge_twin(&self, id: HalfEdgeID)
+    {
+		let mut halfedges = self.halfedges.borrow_mut();
+		if let Some(twin) = halfedges.get(id).unwrap().twin {
+			halfedges.get_mut(twin).unwrap().twin = None;
+		}
+		halfedges.get_mut(id).unwrap().twin = None;
+	}
 
     pub fn vertex_iterator(&self) -> Box<dyn Iterator<Item = VertexID>>
     {

--- a/src/mesh/connectivity_info.rs
+++ b/src/mesh/connectivity_info.rs
@@ -147,15 +147,6 @@ impl ConnectivityInfo {
     {
         RefCell::borrow_mut(&self.faces).get_mut(id).unwrap().halfedge = Some(val);
     }
-    
-    pub fn remove_halfedge_twin(&self, id: HalfEdgeID)
-    {
-		let mut halfedges = self.halfedges.borrow_mut();
-		if let Some(twin) = halfedges.get(id).unwrap().twin {
-			halfedges.get_mut(twin).unwrap().twin = None;
-		}
-		halfedges.get_mut(id).unwrap().twin = None;
-	}
 
     pub fn vertex_iterator(&self) -> Box<dyn Iterator<Item = VertexID>>
     {

--- a/src/mesh/connectivity_info.rs
+++ b/src/mesh/connectivity_info.rs
@@ -236,7 +236,6 @@ pub struct Face {
 pub(crate) struct IDMap<K, V>
 {
     values: Vec<V>,
-    indices: Vec<K>,
     free: Vec<K>
 }
 
@@ -246,7 +245,7 @@ impl<K: 'static, V> IDMap<K, V>
     where K: ID
 {
     pub fn with_capacity(capacity: usize) -> Self {
-        IDMap { values: Vec::with_capacity(capacity), indices: Vec::with_capacity(capacity), free: Vec::new() }
+        IDMap { values: Vec::with_capacity(capacity), free: Vec::new() }
     }
 
     pub fn insert_new(&mut self, value: V) -> Option<K>  {
@@ -258,17 +257,15 @@ impl<K: 'static, V> IDMap<K, V>
             self.values.push(value);
             K::new(self.values.len() as u32 - 1)
         };
-        self.indices.push(id);
         Some(id)
     }
 
     pub fn remove(&mut self, id: K) {
         self.free.push(id);
-        self.indices.retain(|i| *i != id);
     }
 
     pub fn len(&self) -> usize {
-        self.indices.len()
+        self.values.len() - self.free.len()
     }
 
     pub fn get(&self, id: K) -> Option<&V> {
@@ -280,7 +277,6 @@ impl<K: 'static, V> IDMap<K, V>
     }
 
     pub fn iter(&self) -> Box<dyn Iterator<Item = K>> {
-//         Box::new(self.indices.clone().into_iter())
 		let free: HashSet<_> = self.free.iter().cloned().collect();
 		Box::new(   (0 .. self.values.len() as u32)
 					.map(|i| K::new(i))

--- a/src/mesh/connectivity_info.rs
+++ b/src/mesh/connectivity_info.rs
@@ -240,6 +240,8 @@ pub(crate) struct IDMap<K, V>
     free: Vec<K>
 }
 
+use std::collections::HashSet;
+
 impl<K: 'static, V> IDMap<K, V>
     where K: ID
 {
@@ -278,6 +280,10 @@ impl<K: 'static, V> IDMap<K, V>
     }
 
     pub fn iter(&self) -> Box<dyn Iterator<Item = K>> {
-        Box::new(self.indices.clone().into_iter())
+//         Box::new(self.indices.clone().into_iter())
+		let free: HashSet<_> = self.free.iter().cloned().collect();
+		Box::new(   (0 .. self.values.len() as u32)
+					.map(|i| K::new(i))
+					.filter(move |i| !free.contains(&i))   )
     }
 }


### PR DESCRIPTION
To decide whether of halfedge or triangle buffer technique to use for mesh generation I tried to implement extrusion for both case. The result is definitely that is very headache to use halfedge directly because one have to think about a strategy to link all the halfedges to each others and that's not the natural way we think to generation procedures.
In addition I think that most of the time, It would not be less complex to generate the mesh directly in halfedge format, so I would recommend to write the functions in the normal way (triangle buffers) and to load the result into the mesh we want to edit (so call `Mesh::merge_with(Mesh::new(...))`).

Therefore I tried to speed-up the mesh generation from raw buffers. What do you think of it ?
- it uses a hashmap to link halfedges together at the mesh creation
- it no longer copy the indices array when iterating over an `IDMap`

- NOTE for the generatiing functions
As the generation functions knows which part of its result is in common with the original mesh, we would do something like this in order to avoid searching the overlapping primitives
```rust
fn Mesh::extrude(&mut self, ... ) -> Result<()> {
     self.remove( /*  old faces */ ); 
     self.append(Mesh::new( /* generated buffers */));
     self.merge_vertices( /* common vertices */ );
}
```