### PR TITLE
Bevel function for contiguous suite of edges

### DIFF
--- a/src/mesh/connectivity_info.rs
+++ b/src/mesh/connectivity_info.rs
@@ -109,6 +109,15 @@ impl ConnectivityInfo {
         }
         halfedges.remove(halfedge_id);
     }
+	
+	pub fn remove_halfedge_twin(&self, id: HalfEdgeID)
+    {
+		let mut halfedges = self.halfedges.borrow_mut();
+		if let Some(twin) = halfedges.get(id).unwrap().twin {
+			halfedges.get_mut(twin).unwrap().twin = None;
+		}
+		halfedges.get_mut(id).unwrap().twin = None;
+	}
 
     pub fn remove_face(&self, face_id: FaceID)
     {

--- a/src/mesh/edge_measures.rs
+++ b/src/mesh/edge_measures.rs
@@ -39,7 +39,7 @@ impl Mesh
     ///
     pub fn edge_direction(&self, edge: HalfEdgeID) -> Vec3 
     {
-        let (src,dst) = self.edge_positions(edge);
-        (dst-src).normalize()
+        let (dst,src) = self.edge_vertices(edge);
+        (self.vertex_position(dst)-self.vertex_position(src)).normalize()
     }
 }

--- a/src/mesh/edge_measures.rs
+++ b/src/mesh/edge_measures.rs
@@ -33,4 +33,13 @@ impl Mesh
         let (p0, p1) = self.edge_positions(halfedge_id);
         (p0 - p1).magnitude2()
     }
+    
+    ///
+    /// Normalized vector representing the direction in which the halfedge points
+    ///
+    pub fn edge_direction(&self, edge: HalfEdgeID) -> Vec3 
+    {
+        let (src,dst) = self.edge_positions(edge);
+        (dst-src).normalize()
+    }
 }

--- a/src/mesh/edit.rs
+++ b/src/mesh/edit.rs
@@ -108,7 +108,7 @@ impl Mesh
 		// duplicate the vertex
 		let oldvert = self.walker_from_halfedge(start).vertex_id().unwrap();
 		let newvert = self.connectivity_info.new_vertex(self.vertex_position(oldvert));
-		println!("splitting across {}  {:?}  {:?}", oldvert, start, end);
+		println!("splitting across {}  {:?}  {:?}    {}", oldvert, start, end, newvert);
 		// cut at start and at end
 		self.connectivity_info.remove_halfedge_twin(start);
 		self.connectivity_info.remove_halfedge_twin(end);
@@ -119,11 +119,11 @@ impl Mesh
 		// change refs to old vertex between these two halfedges
 		let mut walker = self.walker_from_halfedge(start);
 		while let Some(he) = walker.halfedge_id() {
-            println!("set {:?}  vertex from {} to {}", he, self.connectivity_info.halfedge(he).unwrap().vertex.unwrap(), newvert);
+//             println!("set {:?}  vertex from {} to {}", he, self.connectivity_info.halfedge(he).unwrap().vertex.unwrap(), newvert);
 			self.connectivity_info.set_halfedge_vertex(he, newvert);
 			walker.as_next().as_twin();
-			if walker.halfedge_id() == Some(start)	{println!("reached start");}
-			if walker.halfedge_id() == Some(end)	{println!("reached end");}
+// 			if walker.halfedge_id() == Some(start)	{println!("reached start");}
+// 			if walker.halfedge_id() == Some(end)	{println!("reached end");}
 		}
 		
 		newvert
@@ -482,10 +482,10 @@ impl Mesh
             println!("create face {} {} {}", confront[0][1], confront[0][0], confront[1][1]);
             println!("create face {} {} {}", confront[1][0], confront[1][1], confront[0][0]);
         }
-        println!("halfedges:");
-        for (i,he) in self.halfedge_iter().enumerate() {
-            println!("he {}\t{}\t{:?}", i, he, self.connectivity_info.halfedge(he).unwrap());
-        }
+//         println!("halfedges:");
+//         for (i,he) in self.halfedge_iter().enumerate() {
+//             println!("he {}\t{}\t{:?}", i, he, self.connectivity_info.halfedge(he).unwrap());
+//         }
         self.twin_alones();
     }
 }
@@ -854,22 +854,26 @@ mod tests {
         for face in mesh.face_iter() {
             println!("{:?}", mesh.face_vertices(face));
         }
-        mesh.bevel_curve(&Vec::from_iter([0,4,5].iter().cloned().map(VertexID::new)), 0.1);
 //         println!("halfedges:");
 //         for (i,he) in mesh.halfedge_iter().enumerate() {
 //             println!("he {}\t{}\t{:?}", i, he, mesh.connectivity_info.halfedge(he).unwrap());
 //         }
+		// non-looped
+        mesh.bevel_curve(&Vec::from_iter([0,4,5].iter().cloned().map(VertexID::new)), 0.1);
         assert_eq!(nominal_no_vertices+3, mesh.no_vertices());
         assert_eq!(nominal_no_halfedges+18, mesh.no_halfedges());
         assert_eq!(nominal_no_faces+6, mesh.no_faces());
         mesh.is_valid().unwrap();
         
+        // looped over a face
+        mesh = MeshBuilder::new().icosahedron().build().unwrap();
         mesh.bevel_curve(&Vec::from_iter([0,1,4].iter().cloned().map(VertexID::new)), 0.1);
         assert_eq!(nominal_no_vertices+3, mesh.no_vertices());
         assert_eq!(nominal_no_halfedges+18, mesh.no_halfedges());
         assert_eq!(nominal_no_faces+6, mesh.no_faces());
         mesh.is_valid().unwrap();
         
+        // loop over the whole mesh
         mesh = MeshBuilder::new().icosahedron().build().unwrap();
         mesh.bevel_curve(&Vec::from_iter([0,4,5,3,7,6].iter().cloned().map(VertexID::new)), 0.2);
         mesh.is_valid().unwrap();


### PR DESCRIPTION
This is a function to bevel edges.
It works for a curve (a suite of edges, with no T junction) therefore passed as a `[VertexID]`
This function is not exactly a chamfer function: a chamfer would cut the mesh leaving the remaining faces in the exactly same position and orientation. The stitch function is already there for this purpose.
This operator is more a way to insert a chamfer-like edge, by displacing points around the edge (the neighboring faces are slightly moved, and not cutted).

I want to add a bevel function for vertices too. I will make an other PR.